### PR TITLE
fix: Picture fit set to conver instead of fill

### DIFF
--- a/css/style_card.css
+++ b/css/style_card.css
@@ -21,6 +21,7 @@
     height: 85px;
     border-radius: 50%;
     margin-right: 20px;
+    object-fit: cover;
 }
 
 .container-120824 h2 {


### PR DESCRIPTION
Picture `object-fit` changed to cover to avoid stretching non-square contributor pictures.