### PR TITLE
feat: can use h3 instead of img for the profile picture

### DIFF
--- a/css/style_card.css
+++ b/css/style_card.css
@@ -24,6 +24,17 @@
     object-fit: cover;
 }
 
+h3.card-120824__picture {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 2rem;
+	color: #fdca28;
+	background-color: #05080c;
+    font-family: "Montserrat", sans-serif;
+		font-weight: 500;
+}
+
 .container-120824 h2 {
     font-family: "Montserrat", sans-serif;
     margin: 0;

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 		<main>
 		
 			<div class="card-120824">
-				<img src="static/profile_pics/first.png" alt="first" class="card-120824__picture" loading="lazy">
+				<h3 class="card-120824__picture">ND</h3>
 
 				<div class="container-120824">
 					<h2>Nemo D'ACREMONT</h2>


### PR DESCRIPTION
Enable contributors to use h3 instead of uploading photo (using eirbware logo colors)

![image](https://github.com/user-attachments/assets/ad6c7b4e-4710-455e-9bd9-0845c4facff3)
