### PR TITLE
fix: header logo & card logo aspect ratio

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -174,6 +174,7 @@ footer a {
 .header__logo {
     height: 256px;
     width: 256px;
+    object-fit: contain;
 }
 
 @media (max-width: 767px) {

--- a/css/style_card.css
+++ b/css/style_card.css
@@ -22,6 +22,7 @@
     border-radius: 50%;
     margin-right: 20px;
     object-fit: cover;
+    aspect-ratio: 1;
 }
 
 h3.card-120824__picture {


### PR DESCRIPTION
- On some screen sizes, the header logo used to stretch to a square instead of keeping its original aspect ratio
- On some screen sizes, the card text logo (h3) was being squished horizontally