### PR TITLE
fix: prevent pictures from stretching on chromium based browsers

### DIFF
--- a/css/style_card.css
+++ b/css/style_card.css
@@ -37,7 +37,7 @@ h3.card-120824__picture {
 }
 
 .container-120824 {
-	max-width: calc(100% - 75px);
+	max-width: calc(100% - 75px);  /* 75px: image width + margin */
 }
 
 .container-120824 h2 {

--- a/css/style_card.css
+++ b/css/style_card.css
@@ -36,6 +36,10 @@ h3.card-120824__picture {
 		font-weight: 500;
 }
 
+.container-120824 {
+	max-width: calc(100% - 75px);
+}
+
 .container-120824 h2 {
     font-family: "Montserrat", sans-serif;
     margin: 0;


### PR DESCRIPTION
On phones using chromium based browser, the images were stretched because of the `display: flex;` (see telegram)